### PR TITLE
Adds support for Doc field as in default report

### DIFF
--- a/robotframework_metrics/robotmetrics.py
+++ b/robotframework_metrics/robotmetrics.py
@@ -104,6 +104,11 @@ def generate_report(opts):
     else:
         hide_tags = "hide"
 
+    if opts.showdocs == "True":
+        hide_docs = ""
+    else:
+        hide_docs = "hide"
+
     logging.info(" 4 of 4: Preparing data for dashboard")
     dashboard_obj = Dashboard()
     suite_stats = dashboard_obj.get_suite_statistics(suite_list)
@@ -117,6 +122,7 @@ def generate_report(opts):
     with codecs.open(result_file_name,'w','utf-8') as fh:
         fh.write(template.render(
             hide_tags = hide_tags,
+            hide_docs = hide_docs,
             # hide_keyword_menu = hide_keyword_menu,
             hide_kw_times_menu = hide_kw_times_menu,
             suite_stats = suite_stats,

--- a/robotframework_metrics/runner.py
+++ b/robotframework_metrics/runner.py
@@ -75,6 +75,13 @@ def parse_options():
     )
 
     general.add_argument(
+        '-d', '--showdocs',
+        dest='showdocs',
+        default="False",
+        help="Display test case documentation in test metrics"
+    )
+
+    general.add_argument(
         '-L', '--log',
         dest='log_name',
         default='log.html',

--- a/robotframework_metrics/suite_results.py
+++ b/robotframework_metrics/suite_results.py
@@ -1,4 +1,5 @@
 from robot.api import ResultVisitor
+from robot.utils.markuputils import html_format
 
 
 class SuiteResults(ResultVisitor):
@@ -22,6 +23,7 @@ class SuiteResults(ResultVisitor):
                 "Name" : suite.longname,
                 "Id" : suite.id,
                 "Status" : suite.status,
+                "Documentation" : html_format(suite.doc),
                 "Total" : stats.total,
                 "Pass" : stats.passed,
                 "Fail" : stats.failed,

--- a/robotframework_metrics/templates/index.html
+++ b/robotframework_metrics/templates/index.html
@@ -305,7 +305,7 @@
               <tr>
                   <th>Name</th>
                   <th>Status</th>
-                  <th>Documentation</th>
+                  <th class="{{hide_docs}}">Documentation</th>
                   <th>Total</th>
                   <th>Pass</th>
                   <th>Fail</th>
@@ -324,7 +324,7 @@
                 {% else %}
                   <td style="color: orange"> {{ suite['Status'] }}</td>
                 {% endif %}
-                <td>{{ suite['Documentation'] }}</td>
+                <td class="{{hide_docs}}">{{ suite['Documentation'] }}</td>
                 <td>{{ suite['Total'] }}</td>
                 <td style="color: green">{{ suite['Pass'] }}</td>
                 <td style="color: red">{{ suite['Fail'] }}</td>
@@ -344,7 +344,7 @@
                 <th>Suite Name</th>
                 <th>Test Name</th>
                 <th>Status</th>
-                <th>Documentation</th>
+                <th class="{{hide_docs}}">Documentation</th>
                 <th>Time (s)</th>
                 <th>Message</th>
                 <th class="{{hide_tags}}">Tags</th>
@@ -362,7 +362,7 @@
                 {% else %}
                   <td style="color: orange"> {{ test['Status'] }}</td>
                 {% endif %}
-                <td>{{ test['Documentation'] }}</td>
+                <td class="{{hide_docs}}">{{ test['Documentation'] }}</td>
                 <td>{{ (test['Time']/1000)|round(2) }}</td>
                 <td style="word-wrap: break-word;max-width: 250px; white-space: normal; text-align: left;">{{ test['Message'] }}</td>
                 <td class="{{hide_tags}}" style="word-wrap: break-word;max-width: 250px; white-space: normal; text-align: left;">{{ test['Tags'] }}</td>

--- a/robotframework_metrics/templates/index.html
+++ b/robotframework_metrics/templates/index.html
@@ -305,6 +305,7 @@
               <tr>
                   <th>Name</th>
                   <th>Status</th>
+                  <th>Documentation</th>
                   <th>Total</th>
                   <th>Pass</th>
                   <th>Fail</th>
@@ -323,6 +324,7 @@
                 {% else %}
                   <td style="color: orange"> {{ suite['Status'] }}</td>
                 {% endif %}
+                <td>{{ suite['Documentation'] }}</td>
                 <td>{{ suite['Total'] }}</td>
                 <td style="color: green">{{ suite['Pass'] }}</td>
                 <td style="color: red">{{ suite['Fail'] }}</td>
@@ -342,6 +344,7 @@
                 <th>Suite Name</th>
                 <th>Test Name</th>
                 <th>Status</th>
+                <th>Documentation</th>
                 <th>Time (s)</th>
                 <th>Message</th>
                 <th class="{{hide_tags}}">Tags</th>
@@ -359,6 +362,7 @@
                 {% else %}
                   <td style="color: orange"> {{ test['Status'] }}</td>
                 {% endif %}
+                <td>{{ test['Documentation'] }}</td>
                 <td>{{ (test['Time']/1000)|round(2) }}</td>
                 <td style="word-wrap: break-word;max-width: 250px; white-space: normal; text-align: left;">{{ test['Message'] }}</td>
                 <td class="{{hide_tags}}" style="word-wrap: break-word;max-width: 250px; white-space: normal; text-align: left;">{{ test['Tags'] }}</td>

--- a/robotframework_metrics/test_results.py
+++ b/robotframework_metrics/test_results.py
@@ -1,4 +1,5 @@
 from robot.api import ResultVisitor
+from robot.utils.markuputils import html_format
 
 
 class TestResults(ResultVisitor):
@@ -12,6 +13,7 @@ class TestResults(ResultVisitor):
             "Test Name" : test,
             "Test Id" : test.id,
             "Status" : test.status,
+            "Documentation" : html_format(test.doc),
             "Time" : test.elapsedtime,
             "Message" : test.message,
             "Tags" : test.tags 

--- a/robotframework_metrics/test_results.py
+++ b/robotframework_metrics/test_results.py
@@ -15,7 +15,7 @@ class TestResults(ResultVisitor):
             "Status" : test.status,
             "Documentation" : html_format(test.doc),
             "Time" : test.elapsedtime,
-            "Message" : test.message,
+            "Message" : html_format(test.message),
             "Tags" : test.tags 
         }
         self.test_list.append(test_json)


### PR DESCRIPTION
The report.html created by Robot has these columns by default, which I am planning to use to customize the report. Any custom HTML must be honored (as in the Robot report), hence the extra call to html_format.